### PR TITLE
Update so we may build with Java versions greater or equal to Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 - 1.0.1 Moved to commons version 2.2.3
 - 1.0.0 First release
 - 1.0.2-Beta Fix for ClassNotFoundException: javafx/util/Pair. Added regex support to objects in config.yml
+- 1.0.2 Fix build versions for Java greater than version 11 (XML has been decoupled)
 - 1.0.1-Beta Corrected logging
 - 1.0.0-Beta First beta version

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please do not proceed with the extension installation if the specified prerequis
 
 ## Installation
 
-1. Download and unzip the RedisEnterpriseMonitor-1.0.0.zip to the "<MachineAgent_Dir>/monitors" directory
+1. Download and unzip the RedisEnterpriseMonitor-1.0.2.zip to the "<MachineAgent_Dir>/monitors" directory
 2. Please place the extension in the "monitors" directory of your Machine Agent installation directory. 
    Do not place the extension in the "extensions" directory of your Machine Agent installation directory.
 3. Configure the extension by referring to the section listed below. The metricPrefix of the extension has to be configured as 
@@ -325,7 +325,7 @@ Always feel free to fork and contribute any changes directly via [GitHub](https:
 ## Version
 | Name                        |  Version                    | 
 | :---------------------------| :---------------------------|
-| Extension Version:          | 1.0.1                  |
+| Extension Version:          | 1.0.2                  |
 | Controller Compatibility:   | 2.2 or Later                |
 | Tested On:                  | Redis Enterprise Software v5.4.x       |
 | Operating System Tested On: | Mac OS, Linux               |

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.appdynamics.extensions</groupId>
     <artifactId>redis-enterprise-monitoring-extension</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
     <name>redis-enterprise-monitoring-extension</name>
     <url>http://maven.apache.org</url>
@@ -17,6 +17,21 @@
     </properties>
 
     <dependencies>
+        <dependency>
+        	<groupId>com.sun.xml.bind</groupId>
+        	<artifactId>jaxb-core</artifactId>
+        	<version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+        	<groupId>javax.xml.bind</groupId>
+        	<artifactId>jaxb-api</artifactId>
+        	<version>2.3.1</version>
+        </dependency>
+        <dependency>
+        	<groupId>com.sun.xml.bind</groupId>
+        	<artifactId>jaxb-impl</artifactId>
+        	<version>2.3.1</version>
+        </dependency>
         <dependency>
             <groupId>com.appdynamics</groupId>
             <artifactId>appd-exts-commons</artifactId>


### PR DESCRIPTION
Java 11 and up removes XML so we now need to specifically pull in the XML libraries